### PR TITLE
Fix range request to return 416 when the range is invalid

### DIFF
--- a/Core/HTTPConnection.h
+++ b/Core/HTTPConnection.h
@@ -103,6 +103,7 @@
 - (void)handleResourceNotFound;
 - (void)handleInvalidRequest:(NSData *)data;
 - (void)handleUnknownMethod:(NSString *)method;
+- (void)handleRequestedRangeNotSatisfiable:(UInt64)length;
 
 - (NSData *)preprocessResponse:(HTTPMessage *)response;
 - (NSData *)preprocessErrorResponse:(HTTPMessage *)response;


### PR DESCRIPTION
When range is invalid according to https://tools.ietf.org/html/rfc7233#section-4.4, return 416 Range Not Satisfiable, instead of ignoring the range request.

Ref: https://github.com/couchbase/couchbase-lite-ios/issues/74